### PR TITLE
Update CourseDetails.js fixing issue #12

### DIFF
--- a/client/src/components/CourseDetail.js
+++ b/client/src/components/CourseDetail.js
@@ -69,7 +69,7 @@ export default class CourseDetail extends Component {
                   {course.materialsNeeded &&
                     <li className="course--stats--list--item">
                       <h4>Materials Needed</h4>
-                      <ReactMarkdown source={course.materials} />
+                      <ReactMarkdown source={course.materialsNeeded} />
                     </li>
                   }
                 </ul>


### PR DESCRIPTION
Added Needed to materialsNeeded on line 72 of CourseDetails.js. It allowed the Materials Needed details to show inside the Build a Basic Bookcase.